### PR TITLE
Change WebVOWL link to current working

### DIFF
--- a/app/views/vocabularies/show.jade
+++ b/app/views/vocabularies/show.jade
@@ -129,7 +129,7 @@ block content
                       div#normal-button.moreAppButton(style="width:38px; height:38px; cursor:pointer")
                         img(src='/img/more.png' title='Use external tools to visualise, interact with the vocabulary')
                     div#user-options.toolbar-icons(style="display: none;", classes="tool-container tool-top")
-                      a(href="#{'http://vowl.visualdataweb.org/webvowl/#iri='+((vocab.isDefinedBy)?vocab.isDefinedBy:vocab.uri)}" target='_blank')
+                      a(href="#{'https://service.tib.eu/webvowl/#iri='+((vocab.isDefinedBy)?vocab.isDefinedBy:vocab.uri)}" target='_blank')
                         img(src='/img/viz.png' style="width:38px; height:38px; padding-left:.4em; padding-right:.4em;" title="Visualise this vocabulary in WebVOWL")
                       a(href="#{'http://oops.linkeddata.es/response.jsp?uri='+((vocab.isDefinedBy)?vocab.isDefinedBy:vocab.uri)}" target='_blank')
                         img(src='/img/oops.png' style="width:76px; height:38px" title="Detect pitfalls in this vocabulary")


### PR DESCRIPTION
- Replace previous WebVOWL link with a current one from: https://github.com/VisualDataWeb/WebVOWL (Reason: previous domain is not owned by VisualDataWeb anymore).